### PR TITLE
fix: correção da ordem da tag inscImobFisc na NFSe

### DIFF
--- a/source/.NET Standard/Unimake.Business.DFe/Xml/NFSe/NACIONAL/DPS.cs
+++ b/source/.NET Standard/Unimake.Business.DFe/Xml/NFSe/NACIONAL/DPS.cs
@@ -743,14 +743,14 @@ namespace Unimake.Business.DFe.Xml.NFSe.NACIONAL
 #endif
     public class Obra
     {
+        [XmlElement("inscImobFisc")]
+        public int InscImobFisc { get; set; }
+
         [XmlElement("cObra")]
         public int CObra { get; set; }
 
         [XmlElement("cCIB")]
         public int CCIB { get; set; }
-
-        [XmlElement("inscImobFisc")]
-        public int InscImobFisc { get; set; }
 
         [XmlElement("end")]
         public ServEnd End { get; set; }


### PR DESCRIPTION
Alterei a ordem que exibe a tag inscImobFisc para seguir a sequência do XSD.