### PR TITLE
feat: adicionando valor 9 - outros no RegEspTrib

### DIFF
--- a/source/.NET Standard/Unimake.Business.DFe/Servicos/Enums/Enums.cs
+++ b/source/.NET Standard/Unimake.Business.DFe/Servicos/Enums/Enums.cs
@@ -17460,6 +17460,12 @@ namespace Unimake.Business.DFe.Servicos
         /// </summary>
         [XmlEnum("6")]
         SociedadeProfissionais = 6,
+
+        /// <summary>
+        /// 9 - Outros
+        /// </summary>
+        [XmlEnum("9")]
+        Outros = 9,
     }
     #endregion Tipo de regimes especiais de tributação NFS-e NACIONAL
 


### PR DESCRIPTION
Percebi que no RegEspTrib não tinha essa opção 9, aí adicionei no arquivo.

O valor <regEspTrib>9</regEspTrib> no leiaute da NFS-e Nacional (Ambiente Nacional/BHTISS) representa o regime especial "9-Outros", utilizado especificamente para atender beneficiários do programa Proemp. Essa opção é aplicável quando a NFS-e está vinculada a um Certificado de Incentivo Fiscal (CIF) específico.

Faq:
https://fazenda.pbh.gov.br/nfse/FAQ/

BENEFICIÁRIOS DO PROEMP
As entidades beneficiárias do Programa de Incentivo à Instalação e Ampliação de Empresa
(Proemp) devem emitir suas NFS-e indicando o regime especial "Outros". Para emissão via API,
essa informação deve ser inserida no campo <regEspTrib> do DPS, com o valor "9".
